### PR TITLE
[WIP] add Lurk benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently we are testing the following Zero Knowledge machines
 3. [Triton](https://github.com/TritonVM/triton-vm/)
 4. [Plonk](https://github.com/ZK-Garage/plonk)
 5. [Halo2](https://github.com/zcash/halo2)
+6. [Lurk](https://github.com/lurk-lab/lurk-rs)
 
 If you would like your machine / framework / compilation strategy to
 be benchmarked against the standard suite, please submit a PR! You can

--- a/shootout/Cargo.toml
+++ b/shootout/Cargo.toml
@@ -8,7 +8,8 @@ exclude = [
         "risc",
         "vampir-plonk",
         "vampir-halo2",
-        "zero-knowledge"
+        "zero-knowledge",
+        "lurk"
 ]
 
 [package]
@@ -23,7 +24,7 @@ default = ["all_tests", "all_steps"]
 all = ["all_tests", "all_steps", "all_compilers"]
 
 # Compiler features
-all_compilers = ["miden", "triton", "halo2", "plonk", "vampir_p", "vampir_halo2", "risc"]
+all_compilers = ["miden", "triton", "halo2", "plonk", "vampir_p", "vampir_halo2", "risc", "lurk"]
 
 miden  = ["dep:miden-interface"]
 triton = ["dep:triton"]
@@ -32,6 +33,7 @@ plonk  = ["dep:sudoku_plonk"]
 risc   = ["dep:risc"]
 vampir_p = ["dep:vampir-plonk"]
 vampir_halo2 = ["dep:vampir-halo2"]
+lurk   = ["dep:lurk"]
 
 # Test Features
 
@@ -64,6 +66,7 @@ risc            = { path = "risc"         , optional = true }
 triton          = { path = "triton"       , optional = true }
 vampir-plonk    = { path = "vampir-plonk" , optional = true }
 vampir-halo2    = { path = "vampir-halo2" , optional = true }
+lurk            = { path = "lurk"         , optional = true }
 
 [profile.release]
 debug = 1
@@ -79,3 +82,6 @@ ark-serialize = { git = "https://github.com/simonmasson/algebra", rev = "e2ea75c
 ark-ff        = { git = "https://github.com/simonmasson/algebra", rev = "e2ea75c" }
 ark-ec        = { git = "https://github.com/simonmasson/algebra", rev = "e2ea75c" }
 ark-std       = { git = "https://github.com/arkworks-rs/std/"   , rev = "2b3568f" }
+
+# This is needed for Lurk to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/shootout/lurk/Cargo.toml
+++ b/shootout/lurk/Cargo.toml
@@ -10,6 +10,7 @@ pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev
 lurk = { git = "https://github.com/lurk-lab/lurk-rs", rev = "d65a71ced96b190c31dd1d19ad1f58fed3b9f4aa" }
 camino = "1.1.6"
 zero-knowledge = { path = "../zero-knowledge" }
+tempfile = "3.8.0"
 
 [patch.crates-io]
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin

--- a/shootout/lurk/Cargo.toml
+++ b/shootout/lurk/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+
+[package]
+name = "lurk"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev", features = ["repr-c", "serde"] }
+lurk = { git = "https://github.com/lurk-lab/lurk-rs", rev = "d65a71ced96b190c31dd1d19ad1f58fed3b9f4aa" }
+camino = "1.1.6"
+zero-knowledge = { path = "../zero-knowledge" }
+
+[patch.crates-io]
+# This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }

--- a/shootout/lurk/src/lib.rs
+++ b/shootout/lurk/src/lib.rs
@@ -1,0 +1,134 @@
+use camino::Utf8Path;
+use pasta_curves::{pallas, Fq};
+use std::{cell::OnceCell, sync::Arc};
+
+use lurk::{
+    eval::{
+        empty_sym_env,
+        lang::{Coproc, Lang},
+    },
+    proof::nova::{NovaProver, PublicParams},
+    proof::{nova::Proof, Prover},
+    ptr::GPtr,
+    public_parameters::public_params,
+    store::Store,
+    tag::ExprTag,
+};
+
+// TODO double check it's okay with maintainers to write to temp file. At least switch to using tempfile.
+const PUBLIC_PARAMS_PATH: &str = "/var/tmp/lurk_benches/public_params";
+
+const FIB_PROGRAM: &str = r#"
+(letrec ((next (lambda (a b) (next b (+ a b))))
+           (fib (next 0 1)))
+  (fib))
+"#;
+
+pub struct Lurk {
+    pub reduction_count: usize,
+    pub input: usize,
+    pub name: String,
+}
+
+impl<'a> zero_knowledge::ZeroKnowledge for Lurk {
+    type C = (
+        Option<Store<Fq>>,
+        GPtr<Fq, ExprTag>,
+        NovaProver<Fq, Coproc<Fq>>,
+        Arc<Lang<pallas::Scalar, Coproc<pallas::Scalar>>>,
+        Arc<PublicParams<'static, Fq, Coproc<Fq>>>,
+    );
+    type R = ReceiptWrapper;
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn compile(&self) -> Self::C {
+        let mut store = Store::default();
+        let lang_pallas = Lang::new();
+        let lang_rc = Arc::new(lang_pallas.clone());
+
+        let ptr: GPtr<Fq, _> = store.read(FIB_PROGRAM).unwrap();
+        let prover = NovaProver::new(self.reduction_count, lang_pallas);
+
+        // use cached public params
+        let pp = public_params(
+            self.reduction_count,
+            true,
+            lang_rc.clone(),
+            Utf8Path::new(PUBLIC_PARAMS_PATH),
+        )
+        .unwrap();
+
+        (Some(store), ptr, prover, lang_rc, pp)
+    }
+
+    fn prove(&self, (store, ptr, prover, lang_rc, pp): &mut Self::C) -> Self::R {
+        let mut store = store.take().unwrap();
+        let limit = fib_limit(self.input, self.reduction_count);
+
+        let frames = prover
+            .get_evaluation_frames(
+                *ptr,
+                empty_sym_env(&store),
+                &mut store,
+                limit,
+                lang_rc.clone(),
+            )
+            .unwrap();
+
+        let receipt_wrapper = ReceiptWrapper {
+            receipt: OnceCell::new(),
+            store,
+        };
+
+        receipt_wrapper.receipt.get_or_init(|| {
+            let (proof, z0, zi, num_steps) = prover
+                .prove(&pp, &frames, &receipt_wrapper.store, lang_rc.clone())
+                .unwrap();
+            // SAFETY: a static lifetime transmute is required without refactoring the benchmarking framework
+            //         since lurk proofs include a lifetime to the state object. This is safe in
+            //         this context since the store is dropped after the receipt.
+            (unsafe { std::mem::transmute(proof) }, z0, zi, num_steps)
+        });
+
+        receipt_wrapper
+    }
+
+    fn verify(&self, receipt_wrapper: Self::R, (_, _, _, _, pp): &mut Self::C) {
+        let (proof, z0, zi, num_steps) = receipt_wrapper.receipt.get().unwrap();
+        proof.verify(&pp, *num_steps, &z0, &zi).unwrap();
+    }
+}
+
+/// Wrapper for the Lurk receipt to get around the proof store lifetime being tied to the proof
+/// that needs to be passed on through to the verify step without a lifetime.
+///
+/// This handles it by just having a self-referential struct with a static lifetime. Should not
+/// use any fields manually, and the receipt will be dropped before store.
+pub struct ReceiptWrapper {
+    receipt: OnceCell<(Proof<'static, Fq, Coproc<Fq>>, Vec<Fq>, Vec<Fq>, usize)>,
+
+    store: Store<Fq>,
+}
+
+impl Drop for ReceiptWrapper {
+    fn drop(&mut self) {
+        // SAFETY: Be sure that the proof is dropped first, in case there are some semantics
+        //         in the future that interact with the store on drop.
+        drop(self.receipt.take());
+    }
+}
+
+// The env output in the `fib_frame`th frame of the above, infinite Fibonacci computation will contain a binding of the
+// nth Fibonacci number to `a`.
+fn fib_frame(n: usize) -> usize {
+    11 + 16 * n
+}
+
+// Set the limit so the last step will be filled exactly, since Lurk currently only pads terminal/error continuations.
+fn fib_limit(n: usize, rc: usize) -> usize {
+    let frame = fib_frame(n);
+    rc * (frame / rc + usize::from(frame % rc != 0))
+}

--- a/shootout/src/bench.rs
+++ b/shootout/src/bench.rs
@@ -32,6 +32,8 @@ pub enum ZKP {
     VampIR_Plonk(vampir_plonk::VampIRCircuit),
     #[cfg(feature = "vampir_halo2")]
     VampIR_Halo2(vampir_halo2::VampIRCircuit),
+    #[cfg(feature = "lurk")]
+    Lurk(lurk::Lurk),
     Default,
 }
 
@@ -78,6 +80,8 @@ pub fn name(z: &ZKP) -> String {
         ZKP::VampIR_Plonk(vp) => vp.name(),
         #[cfg(feature = "vampir_halo2")]
         ZKP::VampIR_Halo2(vp) => vp.name(),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(r) => r.name(),
         ZKP::Default => "Error".to_string(),
     }
 }
@@ -101,6 +105,8 @@ pub fn compile_zkp(c: &mut Group, z: ZKP, name: String) {
         ZKP::VampIR_Plonk(vp) => compile(c, vp, name),
         #[cfg(feature = "vampir_halo2")]
         ZKP::VampIR_Halo2(vp) => compile(c, vp, name),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(inner) => compile(c, inner, name),
         ZKP::Default => (),
     }
 }
@@ -122,6 +128,8 @@ pub fn prove_zkp(c: &mut Group, z: ZKP, name: String) {
         ZKP::VampIR_Plonk(vp) => prove(c, vp, name),
         #[cfg(feature = "vampir_halo2")]
         ZKP::VampIR_Halo2(vp) => prove(c, vp, name),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(inner) => prove(c, inner, name),
         ZKP::Default => (),
     }
 }
@@ -143,6 +151,8 @@ pub fn verify_zkp(c: &mut Group, z: ZKP, name: String) {
         ZKP::VampIR_Plonk(vp) => verify(c, vp, name),
         #[cfg(feature = "vampir_halo2")]
         ZKP::VampIR_Halo2(vp) => verify(c, vp, name),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(inner) => verify(c, inner, name),
         ZKP::Default => (),
     }
 }
@@ -164,6 +174,8 @@ pub fn prove_and_verify_zkp(c: &mut Group, z: ZKP, name: String) {
         ZKP::VampIR_Plonk(vp) => prove_and_verify(c, vp, name),
         #[cfg(feature = "vampir_halo2")]
         ZKP::VampIR_Halo2(vp) => prove_and_verify(c, vp, name),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(inner) => prove_and_verify(c, inner, name),
         ZKP::Default => (),
     }
 }

--- a/shootout/src/lurk.rs
+++ b/shootout/src/lurk.rs
@@ -1,0 +1,12 @@
+use ::lurk::Lurk;
+
+pub(crate) struct ReduceCount(pub usize);
+
+pub(crate) fn fib(n: usize, reduction_count: ReduceCount) -> Lurk {
+    let ReduceCount(reduction_count) = reduction_count;
+    Lurk {
+        reduction_count,
+        input: n,
+        name: format!("Lurk: fibonacci-{n} Reduction-{reduction_count}"),
+    }
+}

--- a/shootout/src/main.rs
+++ b/shootout/src/main.rs
@@ -2,6 +2,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 mod bench;
 #[cfg(feature = "halo2")]
 mod halo;
+#[cfg(feature = "lurk")]
+mod lurk;
 #[cfg(feature = "miden")]
 mod miden;
 #[cfg(feature = "plonk")]
@@ -10,12 +12,12 @@ mod plonk;
 mod risc;
 #[cfg(feature = "triton")]
 mod triton;
-#[cfg(feature = "vampir_p")]
-mod vampir_p;
 #[cfg(feature = "vampir_halo2")]
 mod vampir_halo2;
+#[cfg(feature = "vampir_p")]
+mod vampir_p;
 #[cfg(feature = "risc")]
-use ::risc::{FIB_FIFTY_ID, FIB_FIFTY_ELF, FIB_NINTY_TWO_ID, FIB_NINTY_TWO_ELF};
+use ::risc::{FIB_FIFTY_ELF, FIB_FIFTY_ID, FIB_NINTY_TWO_ELF, FIB_NINTY_TWO_ID};
 use bench::*;
 ////////////////////////////////////////
 // Hello, you can place your benchmarks
@@ -73,6 +75,14 @@ pub fn bench_fib(c: &mut Criterion) {
             FIB_NINTY_TWO_ID,
             FIB_NINTY_TWO_ELF,
         )),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(lurk::fib(50, lurk::ReduceCount(100))),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(lurk::fib(93, lurk::ReduceCount(100))),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(lurk::fib(50, lurk::ReduceCount(10))),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(lurk::fib(93, lurk::ReduceCount(10))),
     ];
     #[allow(unused_variables)]
     let fib_sequence_idx = 1000;
@@ -83,6 +93,8 @@ pub fn bench_fib(c: &mut Criterion) {
         ZKP::Miden(miden::fib_iter(fib_sequence_idx)),
         #[cfg(feature = "risc")]
         ZKP::Risc0(risc::fib(fib_sequence_idx as u32)),
+        #[cfg(feature = "lurk")]
+        ZKP::Lurk(lurk::fib(fib_sequence_idx as usize, lurk::ReduceCount(100))),
     ];
     bench_zkp(c, String::from("fibonacci"), to_bench);
     bench_zkp(c, String::from("fibonacci large"), to_bench_large);
@@ -100,7 +112,7 @@ pub fn bench_blake(c: &mut Criterion) {
     ];
     let to_bench_blake3 = vec![
         #[cfg(feature = "miden")]
-        ZKP::Miden(miden::blake3BrownFox())
+        ZKP::Miden(miden::blake3BrownFox()),
     ];
     bench_zkp(c, String::from("Blake"), to_bench_blake2);
     bench_zkp(c, String::from("Blake3"), to_bench_blake3);


### PR DESCRIPTION
Quickly hacked together, just opening for visibility if someone else wants to contribute to this or has something to build off of. The Lurk APIs aren't very compatible with this framework, and likely a lot of this can be streamlined.

Disclaimer that I have no affiliation with the Lurk team, just doing this for my own learning/curiosity.

I'll let the benchmarks run overnight and share to give a rough idea of timings given this setup. Proving was between 10-30s and verify between 100-800ms on my machine for the small fib benchmarks.

<details>
  <summary>First run on local machine</summary>
  
# Benchmarks

## Table of Contents

- [Benchmark Results](#benchmark-results)
    - [fibonacci: compile](#fibonacci:-compile)
    - [fibonacci: prove](#fibonacci:-prove)
    - [fibonacci: verify](#fibonacci:-verify)
    - [fibonacci:](#fibonacci:)
    - [fibonacci large: compile](#fibonacci-large:-compile)
    - [fibonacci large: prove](#fibonacci-large:-prove)
    - [fibonacci large: verify](#fibonacci-large:-verify)
    - [fibonacci large:](#fibonacci-large:)

## Benchmark Results

### fibonacci: compile

|        | `Triton: fibonacci-50`          | `Triton: fibonacci-93`          | `Miden: iter-93`                  | `Miden: fixed-92`                 | `Miden: fixed-50`                 | `Risc0: iter-93`                     | `Risc0: iter-50`                     | `Risc0: fixed-50`                    | `Risc0: fixed-92`                    | `Lurk: fibonacci-50 Reduction-100`          | `Lurk: fibonacci-93 Reduction-100`          | `Lurk: fibonacci-50 Reduction-10`          | `Lurk: fibonacci-93 Reduction-10`           |
|:-------|:--------------------------------|:--------------------------------|:----------------------------------|:----------------------------------|:----------------------------------|:-------------------------------------|:-------------------------------------|:-------------------------------------|:-------------------------------------|:--------------------------------------------|:--------------------------------------------|:-------------------------------------------|:------------------------------------------- |
|        | `43.13 ns` (✅ **1.00x**)        | `44.90 ns` (✅ **1.04x slower**) | `37.94 us` (❌ *879.57x slower*)   | `33.13 us` (❌ *768.15x slower*)   | `27.52 us` (❌ *638.14x slower*)   | `30.82 ms` (❌ *714546.45x slower*)   | `30.64 ms` (❌ *710340.07x slower*)   | `30.47 ms` (❌ *706555.10x slower*)   | `30.11 ms` (❌ *698098.67x slower*)   | `23.30 ms` (❌ *540276.41x slower*)          | `16.64 ms` (❌ *385757.44x slower*)          | `17.22 ms` (❌ *399259.64x slower*)         | `16.57 ms` (❌ *384145.13x slower*)          |

### fibonacci: prove

|        | `Triton: fibonacci-50`          | `Triton: fibonacci-93`           | `Miden: iter-93`                 | `Miden: fixed-92`               | `Miden: fixed-50`               | `Risc0: iter-93`               | `Risc0: iter-50`               | `Risc0: fixed-50`              | `Risc0: fixed-92`              | `Lurk: fibonacci-50 Reduction-100`          | `Lurk: fibonacci-93 Reduction-100`          | `Lurk: fibonacci-50 Reduction-10`          | `Lurk: fibonacci-93 Reduction-10`           |
|:-------|:--------------------------------|:---------------------------------|:---------------------------------|:--------------------------------|:--------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:--------------------------------------------|:--------------------------------------------|:-------------------------------------------|:------------------------------------------- |
|        | `68.40 ms` (✅ **1.00x**)        | `128.82 ms` (❌ *1.88x slower*)   | `135.59 ms` (❌ *1.98x slower*)   | `68.13 ms` (✅ **1.00x faster**) | `71.71 ms` (✅ **1.05x slower**) | `3.79 s` (❌ *55.40x slower*)   | `3.74 s` (❌ *54.64x slower*)   | `3.75 s` (❌ *54.79x slower*)   | `3.75 s` (❌ *54.87x slower*)   | `9.90 s` (❌ *144.76x slower*)               | `16.82 s` (❌ *245.92x slower*)              | `14.07 s` (❌ *205.68x slower*)             | `25.93 s` (❌ *379.14x slower*)              |

### fibonacci: verify

|        | `Triton: fibonacci-50`          | `Triton: fibonacci-93`          | `Miden: iter-93`               | `Miden: fixed-92`              | `Miden: fixed-50`              | `Risc0: iter-93`               | `Risc0: iter-50`               | `Risc0: fixed-50`              | `Risc0: fixed-92`              | `Lurk: fibonacci-50 Reduction-100`          | `Lurk: fibonacci-93 Reduction-100`          | `Lurk: fibonacci-50 Reduction-10`          | `Lurk: fibonacci-93 Reduction-10`           |
|:-------|:--------------------------------|:--------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:--------------------------------------------|:--------------------------------------------|:-------------------------------------------|:------------------------------------------- |
|        | `11.44 ms` (✅ **1.00x**)        | `12.89 ms` (❌ *1.13x slower*)   | `2.13 ms` (🚀 **5.37x faster**) | `2.09 ms` (🚀 **5.47x faster**) | `2.09 ms` (🚀 **5.47x faster**) | `2.92 ms` (🚀 **3.91x faster**) | `2.90 ms` (🚀 **3.95x faster**) | `2.92 ms` (🚀 **3.92x faster**) | `3.00 ms` (🚀 **3.81x faster**) | `699.58 ms` (❌ *61.18x slower*)             | `711.20 ms` (❌ *62.19x slower*)             | `109.23 ms` (❌ *9.55x slower*)             | `111.75 ms` (❌ *9.77x slower*)              |

### fibonacci:

|        | `Triton: fibonacci-50`          | `Triton: fibonacci-93`           | `Miden: iter-93`                 | `Miden: fixed-92`               | `Miden: fixed-50`               | `Risc0: iter-93`               | `Risc0: iter-50`               | `Risc0: fixed-50`              | `Risc0: fixed-92`              | `Lurk: fibonacci-50 Reduction-100`          | `Lurk: fibonacci-93 Reduction-100`          | `Lurk: fibonacci-50 Reduction-10`          | `Lurk: fibonacci-93 Reduction-10`           |
|:-------|:--------------------------------|:---------------------------------|:---------------------------------|:--------------------------------|:--------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:-------------------------------|:--------------------------------------------|:--------------------------------------------|:-------------------------------------------|:------------------------------------------- |
|        | `85.14 ms` (✅ **1.00x**)        | `150.05 ms` (❌ *1.76x slower*)   | `137.30 ms` (❌ *1.61x slower*)   | `70.54 ms` (✅ **1.21x faster**) | `74.03 ms` (✅ **1.15x faster**) | `3.87 s` (❌ *45.42x slower*)   | `3.86 s` (❌ *45.38x slower*)   | `3.90 s` (❌ *45.75x slower*)   | `3.86 s` (❌ *45.38x slower*)   | `10.58 s` (❌ *124.29x slower*)              | `17.52 s` (❌ *205.79x slower*)              | `14.21 s` (❌ *166.93x slower*)             | `25.87 s` (❌ *303.82x slower*)              |

### fibonacci large: compile

|        | `Triton: fibonacci-1000`          | `Miden: iter-1000`                | `Risc0: iter-1000`                   | `Lurk: fibonacci-1000 Reduction-100`          | `Lurk: fibonacci-1000 Reduction-10`           |
|:-------|:----------------------------------|:----------------------------------|:-------------------------------------|:----------------------------------------------|:--------------------------------------------- |
|        | `49.94 ns` (✅ **1.00x**)          | `38.06 us` (❌ *762.25x slower*)   | `30.77 ms` (❌ *616218.46x slower*)   | `16.75 ms` (❌ *335484.88x slower*)            | `16.57 ms` (❌ *331822.51x slower*)            |

### fibonacci large: prove

|        | `Triton: fibonacci-1000`          | `Miden: iter-1000`            | `Risc0: iter-1000`            | `Lurk: fibonacci-1000 Reduction-100`          | `Lurk: fibonacci-1000 Reduction-10`           |
|:-------|:----------------------------------|:------------------------------|:------------------------------|:----------------------------------------------|:--------------------------------------------- |
|        | `2.06 s` (✅ **1.00x**)            | `1.12 s` (🚀 **1.84x faster**) | `3.89 s` (❌ *1.89x slower*)   | `189.23 s` (❌ *91.97x slower*)                | `276.43 s` (❌ *134.36x slower*)               |

### fibonacci large: verify

|        | `Triton: fibonacci-1000`          | `Miden: iter-1000`             | `Risc0: iter-1000`             | `Lurk: fibonacci-1000 Reduction-100`          | `Lurk: fibonacci-1000 Reduction-10`           |
|:-------|:----------------------------------|:-------------------------------|:-------------------------------|:----------------------------------------------|:--------------------------------------------- |
|        | `20.66 ms` (✅ **1.00x**)          | `2.38 ms` (🚀 **8.69x faster**) | `2.95 ms` (🚀 **7.01x faster**) | `699.12 ms` (❌ *33.84x slower*)               | `114.04 ms` (❌ *5.52x slower*)                |

### fibonacci large:

|        | `Triton: fibonacci-1000`          | `Miden: iter-1000`            | `Risc0: iter-1000`            | `Lurk: fibonacci-1000 Reduction-100`          | `Lurk: fibonacci-1000 Reduction-10`           |
|:-------|:----------------------------------|:------------------------------|:------------------------------|:----------------------------------------------|:--------------------------------------------- |
|        | `2.11 s` (✅ **1.00x**)            | `1.11 s` (🚀 **1.90x faster**) | `4.18 s` (❌ *1.98x slower*)   | `195.70 s` (❌ *92.86x slower*)                | `291.43 s` (❌ *138.28x slower*)               |

---
Made with [criterion-table](https://github.com/nu11ptr/criterion-table)


  ```
</details>